### PR TITLE
#162183607 Feat: Setup api endpoint to get specific red-flag record

### DIFF
--- a/app/routes/api/v1/index.js
+++ b/app/routes/api/v1/index.js
@@ -22,5 +22,15 @@ router.get('/red-flags/',(req,res) =>{
     echo(res,config.STATUS_OK,incidents.getIncidents());
 });
 
+router.get('/red-flags/:id',(req,res) =>{
+    const incident=incidents.getIncident(req.params.id);
+    if (incident===false) {
+        error(res,config.STATUS_NOT_FOUND,'No incident matching that id');
+    }
+    else{
+        echo(res,config.STATUS_OK,incident);
+    }
+});
+
 
 module.exports = router;

--- a/test/http-get-test.js
+++ b/test/http-get-test.js
@@ -25,6 +25,31 @@ describe('API endpoints for get requests', () =>{
                     expect(res.body.status).to.equal(config.STATUS_OK);
                     expect(res.body.data).to.be.an('array');
         });
-    });  
+    });
     
+    it('should get a specific incident with id 34567', function () {
+        chai.request(app)
+                .get('/api/v1/red-flags/34567')
+                .then((res) =>{
+                    expect(res).to.have.status(config.STATUS_OK);
+                    expect(res).to.be.json;
+                    expect(res.body).to.have.property('status');
+                    expect(res.body).to.have.property('data');
+                    expect(res.body.status).to.equal(config.STATUS_OK);
+                    expect(res.body.data).to.be.an('array');
+        });
+    });
+    
+    it('should return 404 not found error for invalid incident id', function () {
+        chai.request(app)
+                .get('/api/v1/red-flags/INVALID_ID')
+                .then((res) =>{
+                    expect(res).to.have.status(config.STATUS_NOT_FOUND);
+                    expect(res).to.be.json;
+                    expect(res.body).to.have.property('status');
+                    expect(res.body).to.have.property('error');
+                    expect(res.body.status).to.equal(config.STATUS_NOT_FOUND);
+                    expect(res.body.error).to.be.an('string');
+        });
+    });    
 });


### PR DESCRIPTION
**What does this PR do?**
This PR sets up the GET /api/v1/red-flags/:id endpoint to get a specific red-flag record

**Description of tasks**
* Implement unit test for the endpoint
* Setup API endpoint for GET /api/v1/red-flags/:id and make sure all tests are passing
* API endpoint should return the details of the red-flag record matching the specified id

**How can this PR be tested**

* Using Postman, set the request method to GET
* Make requests to https://ireporter-nigeria.herokuapp.com/api/v1/red-flags/id where id can be the id of any red-flag record.

Link to relevant story
[#162183607](https://www.pivotaltracker.com/story/show/162183607)